### PR TITLE
refactor/[DSBL-70] Palette

### DIFF
--- a/src/lib/pirate-button/index.js
+++ b/src/lib/pirate-button/index.js
@@ -3,23 +3,19 @@ import { Button } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import Layout from '../layout';
 
-const useStyles = makeStyles((theme) => {
-  return {
-  root: {
-    color: theme.palette.secondary.contrastText,
-    backgroundColor: theme.palette.grey[900]
-  }
-}
-});
+const PirateButton = ({ style }) => {
+  const useStyles = makeStyles((theme) => ({
+    root: {
+      color: theme.palette[style].contrastText,
+      backgroundColor: theme.palette[style].main
+    },
+  }))
 
-const PirateButton = () => {
   const classes = useStyles();
 
   return (
-    <Button classes={{
-      root: classes.root,
-    }}
-    color="primary" variant="contained">
+    <Button className={classes.root}
+    variant="contained">
       Pirate Button!
     </Button>
   );
@@ -27,6 +23,11 @@ const PirateButton = () => {
 
 export default (props) => (
   <Layout>
-    <PirateButton {...props} />
+    <PirateButton style="primary" {...props} />
+    <PirateButton style="secondary" {...props} />
+    <PirateButton style="tertiary" {...props} />
+    <PirateButton style="error" {...props} />
+    <PirateButton style="success" {...props} />
+    <PirateButton style="grey" {...props} />
   </Layout>
 );


### PR DESCRIPTION
## Refactor Palette

Altera estrutura de makeStyle, passa useStyles para escopo do componente para receber style como prop

## Capturas de Tela
![image](https://user-images.githubusercontent.com/42470334/92647710-b9045b80-f2be-11ea-950f-add1e800f684.png)


## Issue do Repositório 

Issue #3

## Issue do JIRA
[DSBL-70](https://beyondlabs.atlassian.net/jira/software/projects/DSBL/boards/30?selectedIssue=DSBL-70)

## Descrição técnica da solução

- Importa paleta de cores a partir do componente `Layout`;

- Sobrescreve referência de `color` de material UI;
- Cria referência dinâmica a partir de `style` passada como `prop` no componente de exemlpo, `PirateButton`.